### PR TITLE
Disable SSPLIT/CSPLIT packets when a low/full speed device is connected directly to the root hub

### DIFF
--- a/source/hcd/dwc/designware20.c
+++ b/source/hcd/dwc/designware20.c
@@ -368,33 +368,31 @@ Result HcdChannelSendWaitOne(struct UsbDevice *device,
 		ReadBackReg(&Host->Channel[channel].TransferSize);
 		
 		if (pipe->Speed != High) {
-			if (Host->Channel[channel].Interrupt.Acknowledgement) {
-				if (Host->Channel[channel].SplitControl.SplitEnable) {
-					for (tries = 0; tries < 3; tries++) {
-						SetReg(&Host->Channel[channel].Interrupt);
-						WriteThroughReg(&Host->Channel[channel].Interrupt);
+			if ((Host->Channel[channel].Interrupt.Acknowledgement) && (Host->Channel[channel].SplitControl.SplitEnable)) {
+				for (tries = 0; tries < 3; tries++) {
+					SetReg(&Host->Channel[channel].Interrupt);
+					WriteThroughReg(&Host->Channel[channel].Interrupt);
 
-						ReadBackReg(&Host->Channel[channel].SplitControl);
-						Host->Channel[channel].SplitControl.CompleteSplit = true;
-						WriteThroughReg(&Host->Channel[channel].SplitControl);
+					ReadBackReg(&Host->Channel[channel].SplitControl);
+					Host->Channel[channel].SplitControl.CompleteSplit = true;
+					WriteThroughReg(&Host->Channel[channel].SplitControl);
 					
-						Host->Channel[channel].Characteristic.Enable = true;
-						Host->Channel[channel].Characteristic.Disable = false;
-						WriteThroughReg(&Host->Channel[channel].Characteristic);
+					Host->Channel[channel].Characteristic.Enable = true;
+					Host->Channel[channel].Characteristic.Disable = false;
+					WriteThroughReg(&Host->Channel[channel].Characteristic);
 
-						timeout = 0;
-						do {
-							if (timeout++ == RequestTimeout) {
-								LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
-								device->Error = ConnectionError;
-								return ErrorTimeout;
-							}
-							ReadBackReg(&Host->Channel[channel].Interrupt);
-							if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
-							else break;
-						} while (true);
-						if (!Host->Channel[channel].Interrupt.NotYet) break;
-					}
+					timeout = 0;
+					do {
+						if (timeout++ == RequestTimeout) {
+							LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
+							device->Error = ConnectionError;
+							return ErrorTimeout;
+						}
+						ReadBackReg(&Host->Channel[channel].Interrupt);
+						if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
+						else break;
+					} while (true);
+					if (!Host->Channel[channel].Interrupt.NotYet) break;
 				}
 
 				if (tries == 3) {

--- a/source/hcd/dwc/designware20.c
+++ b/source/hcd/dwc/designware20.c
@@ -247,7 +247,7 @@ Result HcdPrepareChannel(struct UsbDevice *device, u8 channel,
 
 	// Clear split control.
 	ClearReg(&Host->Channel[channel].SplitControl);
-	if (pipe->Speed != High) {
+	if ((pipe->Speed != High) && (device->Parent != NULL) && (device->Parent->Speed == High) && (device->Parent->Parent != NULL)) {
 		Host->Channel[channel].SplitControl.SplitEnable = true;
 		Host->Channel[channel].SplitControl.HubAddress = device->Parent->Number;
 		Host->Channel[channel].SplitControl.PortAddress = device->PortNumber;			

--- a/source/hcd/dwc/designware20.c
+++ b/source/hcd/dwc/designware20.c
@@ -367,32 +367,34 @@ Result HcdChannelSendWaitOne(struct UsbDevice *device,
 		} while (true);
 		ReadBackReg(&Host->Channel[channel].TransferSize);
 		
-		if (Host->Channel[channel].SplitControl.SplitEnable) {
+		if (pipe->Speed != High) {
 			if (Host->Channel[channel].Interrupt.Acknowledgement) {
-				for (tries = 0; tries < 3; tries++) {
-					SetReg(&Host->Channel[channel].Interrupt);
-					WriteThroughReg(&Host->Channel[channel].Interrupt);
+				if (Host->Channel[channel].SplitControl.SplitEnable) {
+					for (tries = 0; tries < 3; tries++) {
+						SetReg(&Host->Channel[channel].Interrupt);
+						WriteThroughReg(&Host->Channel[channel].Interrupt);
 
-					ReadBackReg(&Host->Channel[channel].SplitControl);
-					Host->Channel[channel].SplitControl.CompleteSplit = true;
-					WriteThroughReg(&Host->Channel[channel].SplitControl);
+						ReadBackReg(&Host->Channel[channel].SplitControl);
+						Host->Channel[channel].SplitControl.CompleteSplit = true;
+						WriteThroughReg(&Host->Channel[channel].SplitControl);
 					
-					Host->Channel[channel].Characteristic.Enable = true;
-					Host->Channel[channel].Characteristic.Disable = false;
-					WriteThroughReg(&Host->Channel[channel].Characteristic);
+						Host->Channel[channel].Characteristic.Enable = true;
+						Host->Channel[channel].Characteristic.Disable = false;
+						WriteThroughReg(&Host->Channel[channel].Characteristic);
 
-					timeout = 0;
-					do {
-						if (timeout++ == RequestTimeout) {
-							LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
-							device->Error = ConnectionError;
-							return ErrorTimeout;
-						}
-						ReadBackReg(&Host->Channel[channel].Interrupt);
-						if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
-						else break;
-					} while (true);
-					if (!Host->Channel[channel].Interrupt.NotYet) break;
+						timeout = 0;
+						do {
+							if (timeout++ == RequestTimeout) {
+								LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
+								device->Error = ConnectionError;
+								return ErrorTimeout;
+							}
+							ReadBackReg(&Host->Channel[channel].Interrupt);
+							if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
+							else break;
+						} while (true);
+						if (!Host->Channel[channel].Interrupt.NotYet) break;
+					}
 				}
 
 				if (tries == 3) {


### PR DESCRIPTION
This PR adds support for low/full speed devices directly connected to the root hub. It makes possible to connect USB HID devices directly to no-onboard-USB-hub models of Raspberry Pi (Zero series and A Series).